### PR TITLE
Fix header/headers mismatch issue

### DIFF
--- a/packages/overreact/src/middleware/wrapped-requestor.js
+++ b/packages/overreact/src/middleware/wrapped-requestor.js
@@ -4,7 +4,7 @@ export class WrappedRequestor {
       requestor,
       uri,
       verb,
-      header,
+      headers,
       payload,
       spec,
       variables,
@@ -16,7 +16,7 @@ export class WrappedRequestor {
     this.requestor = requestor;
     this.uri = uri;
     this.verb = verb;
-    this.header = header;
+    this.headers = headers;
     this.payload = payload;
     this.variables = variables;
     this.spec = spec;
@@ -28,6 +28,6 @@ export class WrappedRequestor {
   }
 
   executeRequest() {
-    return this.requestor(this.uri, this.verb, this.header, this.payload);
+    return this.requestor(this.uri, this.verb, this.headers, this.payload);
   }
 }


### PR DESCRIPTION
This bug is introduced by this [commit](https://github.com/microsoft/overreact-core/commit/7e20967694aa2fc14d707dd999382fca6859cb8a) in packages/overreact/src/environment/environment.js:

The passed in param name has changed from `header` to `headers`, but forget to change it in packages/overreact/src/middleware/wrapped-requestor.js
![image](https://user-images.githubusercontent.com/32892728/153224698-2f8c4b98-fabc-4c8d-9895-3875b3459c98.png)
