### PR TITLE
Fix crash in FireFox

### DIFF
--- a/packages/overreact/src/hooks/use-component.js
+++ b/packages/overreact/src/hooks/use-component.js
@@ -21,13 +21,14 @@ export function useComponent() {
         const stackSegs = stacks[i].trim().split(' ');
 
         // we only need the 2nd segment, which is the function name
-        const funcName = stackSegs[1];
+        const funcName = stackSegs[1] || '';
 
         // we'll ignore anything that is a React hook
-        if (funcName.startsWith('use')
+        if (!funcName
         || funcName === 'eval'
         || funcName === 'mountMemo'
-        || funcName === 'Object.useMemo') {
+        || funcName === 'Object.useMemo'
+        || funcName.startsWith('use')) {
           continue;
         }
 


### PR DESCRIPTION
In Firefox, the error format is differrent from google chrome.
![image](https://user-images.githubusercontent.com/32892728/154967430-c1bd5476-dd57-4caa-be2d-c05652b1a1a4.png)
`funcName` will be `undefined` after `splite` of error.
Then call `startsWith` of `undefined` will make page crash